### PR TITLE
Allow override of env provided to tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ typings/*
 npm_debug
 coverage/
 npm-debug.log
+.idea/

--- a/src/tasks/DecisionTask.ts
+++ b/src/tasks/DecisionTask.ts
@@ -54,10 +54,10 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
   setExecutionContext(context: any) {
     this.executionContext = context
   }
-  private buildTaskInput(input: any): string {
+  private buildTaskInput(input: any, overrideEnv?: any): string {
     return JSON.stringify({
       input: input,
-      env: this.getEnv(),
+      env: overrideEnv || this.getEnv(),
       originWorkflow: this.getOriginWorkflow()
     } as TaskInput)
   }
@@ -170,9 +170,9 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
     })
     return true
   }
-  scheduleTask(activityId: string, input: any, activity: ActivityType, opts: ConfigOverride = {}) {
+  scheduleTask(activityId: string, input: any, activity: ActivityType, opts: ConfigOverride = {}, overrideEnv?: any) {
     let maxRetry = opts['maxRetry'] as number || activity.maxRetry
-    let taskInput = this.buildTaskInput(input)
+    let taskInput = this.buildTaskInput(input, overrideEnv)
     this.decisions.push({
       entities: ['activity'],
       overrides: opts,
@@ -190,7 +190,7 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
       }
     })
   }
-  startChildWorkflow(workflowId: string, input: any, opts: ConfigOverride = {}) {
+  startChildWorkflow(workflowId: string, input: any, opts: ConfigOverride = {}, overrideEnv?: any) {
     let maxRetry = opts['maxRetry'] as number
     this.decisions.push({
       entities: ['workflow', 'decision'],
@@ -203,7 +203,7 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
             name: this.workflow.name,
             version: this.workflow.version
           },
-          input: this.buildTaskInput(input),
+          input: this.buildTaskInput(input, overrideEnv),
           control: JSON.stringify(this.buildInitialControlDoc(maxRetry))
         }
       }
@@ -222,8 +222,8 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
       }
     })
   }
-  completeWorkflow(result: TaskStatus, opts: ConfigOverride = {}) {
-    result.env = this.getEnv()
+  completeWorkflow(result: TaskStatus, opts: ConfigOverride = {}, overrideEnv?: any) {
+    result.env = overrideEnv || this.getEnv()
     this.decisions.push({
       entities: ['workflow'],
       overrides: opts,
@@ -289,9 +289,9 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
       }
     })
   }
-  continueAsNewWorkflow(overrideInput: string | null = null, opts: ConfigOverride = {}) {
+  continueAsNewWorkflow(overrideInput: string | null = null, opts: ConfigOverride = {}, overrideEnv?: any) {
     let params: SWF.ContinueAsNewWorkflowExecutionDecisionAttributes = {
-      input: this.buildTaskInput(overrideInput || this.workflowAttrs.input),
+      input: this.buildTaskInput(overrideInput || this.workflowAttrs.input, overrideEnv),
       childPolicy: this.workflowAttrs.childPolicy,
       executionStartToCloseTimeout: this.workflowAttrs.executionStartToCloseTimeout,
       lambdaRole: this.workflowAttrs.lambdaRole,
@@ -310,7 +310,7 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
       }
     })
   }
-  scheduleLambda(lambdaName: string, id: string, input: any, opts: ConfigOverride = {}) {
+  scheduleLambda(lambdaName: string, id: string, input: any, opts: ConfigOverride = {}, overrideEnv?: any) {
     this.decisions.push({
       entities: ['activity'],
       overrides: opts,
@@ -319,7 +319,7 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
         scheduleLambdaFunctionDecisionAttributes: {
           id: id,
           name: lambdaName,
-          input: this.buildTaskInput(input),
+          input: this.buildTaskInput(input, overrideEnv),
         }
       }
     })


### PR DESCRIPTION
Hi guys - I've been meaning to write up a detailed greeting in the ftl-engine project including our use cases for simple-swf and ftl-engine, but haven't had the time to think it through fully, and we've been in 'quick and dirty' mode coming up to a deadline, so I hope you'll forgive me :).

However, I do have a small enhancement I'd like to request here.  We would like to be able to have finer control over the env provided to tasks and taskGraph based workflow executions that are being dispatched from the decider -- for two main reasons:
1. When a taskGraph workflow runs a 'sub' workflow as a task, the env the sub-workflow would be working with/expect may be drastically different than the env of the workflow that spawned it; currently, all sub-workflows see the same (eventually huge and always claim checked) env, even if what they are working with would be a tiny subset of the overall env.  It would be nice to be able to transform the env passed into the child workflow so that the child workflow receives the same env structure, even if it's running on different data from the parent workflow's environment.  This is a lot like what you guys use 'expandArgs' for in ftl-engine processor, but our use case is too dynamic for static generation of all parameters up front; we need to use env alot.
2. When a workflow returns results in env, the resulting env is mixed into the parent workflow's env.  This means that if multiple runs of the same workflow are dispatched, the parent workflow's env always gets results of child workflows placed in the same key of 'env', overwriting each-other as each task completes.  We would like to be able to easily transform the env before it is passed in to completeWorkflow() in the decider, so that we can control where in the parent env the value can be found (we define this in our workflow definitions)

These two behaviors combined really inhibit our re-use of workflows or activities.  For example, a CopyEntity workflow for us might look like:

```
CopyEntity(parameters =  {docIds: [ sourceTemplateId, sourceComponentId, destTemplateId,, destComponentId ] } })
--> getDocs(parameters.docIds) --> env.docs
----> performTaskTypeA( { targetDocuments: [ env.docs[0], env.docs[1] } ) --> env.sourceTaskTypeAResult
----> performTaskTypeA( { targetDocuments: [ env.docs[2], env.docs[3] } ) --> env.destTaskTypeAResult
----> performTaskTypeB( { targetDocuments: [ env.docs[0], env.docs[1] } ) --> env.sourceTaskTypeBResult
----> performTaskTypeB( { targetDocuments: [ env.docs[2], env.docs[3] } ) --> env.destTaskTypeBResult
```

Note that by way of the buildTaskInput behavior I'm proposing, I provided a transformed env to the performTaskTypeA workflow that is a consistent structure, even though it's working on different data from the parent/spawning workflow. Likewise, by way of the change to completeWorkflow(), I also controlled which props in env on the parent workflow the result of the two TaskTypeA() calls are placed, even though they return the same keys in their env responses.

Next:

```
--------> respondSuccess({taskTypeAResults: { source: env.sourceTaskTypeAResult, dest: env.destTaskTypeAResult }, taskTypeBResults: {...} })
```

Note that this could be a subworkflow.  If it was, it might run the return value above through it's own output() function so that the parent workflow receives the env it expects back from the child workflow.

I hope that this was a clear explanation!  

I have also a commit to add my IDE configuration folder to .gitignore, if you are willing to allow it so I can contribute easier :)

Thanks for your consideration.
