### PR TITLE
Move @types for node and chai to dependencies to avoid TS2688 errors …

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/async": "^2.0.32",
-    "@types/chai": "^3.4.34",
     "@types/es6-promise": "0.0.32",
     "@types/lodash": "^4.14.37",
     "@types/mocha": "^2.2.32",
-    "@types/node": "^6.0.45",
     "@types/shortid": "0.0.28",
     "@types/sinon": "^1.16.31",
     "chai": "^3.5.0",
@@ -42,6 +40,8 @@
     "typings": "^1.3.1"
   },
   "dependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/node": "^6.0.45",
     "async": "^2.0.32",
     "aws-sdk": "^2.3.3",
     "in-publish": "^2.0.0",


### PR DESCRIPTION
When installing ftl-engine using the 0.2.0-beta of simple-swf, errors similar to the following are displayed for many source files:

```
../simple-swf/build/src/entities/Activity.d.ts(1,1): error TS2688: Cannot find type definition file for 'node'.
../simple-swf/build/src/entities/Activity.d.ts(2,1): error TS2688: Cannot find type definition file for 'chai'.
```

Because the files in the build directory have <reference> tags to node and chai, but simple-swf has those listed only as dev dependencies.

npm install was not adding node and chai to node_modules/@types during install, so build/test was failing.  Moving these @types references to 'dependencies' rather than 'devDependencies' allows 0.2.0-beta of simple-swf to work without the parent package manually adding node and chai @types to its dependencies/devdependencies.
