### PR TITLE
Fix isChildWorkflow() returning true 100% of the time

### DIFF
--- a/src/tasks/DecisionTask.ts
+++ b/src/tasks/DecisionTask.ts
@@ -98,7 +98,7 @@ export class DecisionTask extends Task<SWF.DecisionTask> {
     return this.rawTask.events[0].workflowExecutionStartedEventAttributes!.parentWorkflowExecution || null
   }
   isChildWorkflow(): boolean {
-    return this.getParentWorkflowInfo != null
+    return this.getParentWorkflowInfo() !== null
   }
   rescheduleTimedOutEvents(): Event[] {
     let timedOut = this.rollup.getTimedOutEvents()


### PR DESCRIPTION
isChildWorkflow() was checking for the existence of the getParentWorkflowInfo() method rather than checking the result of calling the method.  This PR ensures that getParentWorkflowInfo() is called in isChildWorkflow()
