### PR TITLE
Ensure properties for events returned by processEvents() are accurate

### DIFF
--- a/src/tasks/processEvents.ts
+++ b/src/tasks/processEvents.ts
@@ -305,7 +305,7 @@ export function processEvents(events) {
       } else {
         oldEvent = grouped[transition.from] || {}
       }
-      grouped[transition.to] = _.merge(oldEvent, event)
+      grouped[transition.to] = _.merge(_.clone(oldEvent), event)
       // allow the transitions to transform the state to add other properties we may want
       if (transition.transform) {
         transition.transform(grouped, event)


### PR DESCRIPTION
I noticed while adding support for Timer events to simple-swf (a PR for that is incoming 'soon', BTW :)) that all events for a particular task (decision, workflow, activity) had their props for eventTimestamp, eventType and eventId set to whatever the values for those props were in the latest event for that task.

I tracked the source of the issue down to processEvents, where a new event's properties were being merged into the 'from' oldEvent without cloning it.

This PR modifies processEvents() so that oldEvent is cloned before merging current event properties into it, so that previous events for a particular task have accurate values for those props. I think the discrepancy was overlooked because the data in byEventId{} is usually used, and that is always accurate.

Note: I used clone() rather than cloneDeep(), so individual events attributes (ex: timerStartedEventAttributes, timerFiredEventAttributes)  are not duplicated, just the main event so that the primary props are properly updated.

Without this patch:
```javascript
    "Timer1": {
      "current": "completed",
      "started": {
        "eventTimestamp": "2017-04-15T00:11:32.006Z",
        "eventType": "TimerFired",
        "eventId": 12,
        "timerStartedEventAttributes": {
          "timerId": "Timer1",
          "startToFireTimeout": "5",
          "decisionTaskCompletedEventId": 4
        }
      },
      "completed": {
        "eventTimestamp": "2017-04-15T00:11:32.006Z",
        "eventType": "TimerFired",
        "eventId": 12,
        "timerStartedEventAttributes": {
          "timerId": "Timer1",
          "startToFireTimeout": "5",
          "decisionTaskCompletedEventId": 4
        },
        "timerFiredEventAttributes": {
          "timerId": "Timer1",
          "startedEventId": 5
        }
      }
    }
```
With this patch:
```javascript
    "Timer1": {
      "current": "completed",
      "started": {
        "eventTimestamp": "2017-04-15T00:11:27.005Z",
        "eventType": "TimerStarted",
        "eventId": 5,
        "timerStartedEventAttributes": {
          "timerId": "Timer1",
          "startToFireTimeout": "5",
          "decisionTaskCompletedEventId": 4
        }
      },
      "completed": {
        "eventTimestamp": "2017-04-15T00:11:32.006Z",
        "eventType": "TimerFired",
        "eventId": 12,
        "timerStartedEventAttributes": {
          "timerId": "Timer1",
          "startToFireTimeout": "5",
          "decisionTaskCompletedEventId": 4
        },
        "timerFiredEventAttributes": {
          "timerId": "InitialTimer",
          "startedEventId": 5
        }
      }
    }
```